### PR TITLE
Update references-fa18-523-61.bib

### DIFF
--- a/bib/references-fa18-523-61.bib
+++ b/bib/references-fa18-523-61.bib
@@ -34,7 +34,7 @@
 }
 
 @Misc{foodfightshow.org,
-  author       = {Jeff Hagadorn, Sean O'Meara, Joshua Timberman, Bryan Berry, Nathen Harvey},
+  author       = {Jeff Hagadorn and Sean O'Meara and Joshua Timberman and Bryan Berry and Nathen Harvey},
   title        = {Roles, Environments, Attributes, and Data Bags - Part 2},
   howpublished = {Web Page},
   url          = {http://foodfightshow.org/2013/01/roles2.html},


### PR DESCRIPTION
Replaced commas in foodfight.org entry with 'and' to correctly reflect multiple authors. 