### PR TITLE
conflict: Updated bib and tech summaries

### DIFF
--- a/bib/references-fa18-523-61.bib
+++ b/bib/references-fa18-523-61.bib
@@ -1,37 +1,43 @@
-@Misc{en.wikipedia.sqlite,
-  comment =      {ERROR},
-  title =        {SQLite},
-  howpublished = {Web Page},
+@Misc{wwww-en-wikipedia-sqlite,
+  comment =      {Added author,'www', and key},
+  author  =      {{Wikipedia}},
+  title =        {SQlite},
+  howpublished = {Web page},
+  key          + {Sqlite},
   url =          {https://en.wikipedia.org/wiki/SQLite},
 }
 
-@Misc{sqliteappformat,
-  comment =      {ERROR},
+@Misc{www-sqliteappformat,
+  comment =      {Added key and 'www' to label},
   title =        {SQlite As An Application File Format},
-  howPublished = {Web Page},
+  howPublished = {Web page},
+  key          = {Sqlite},
   url =          {https://www.sqlite.org/aff_short.html},
 }
 
-@Misc{sqlitedownload,
-  comment =      {ERROR},
+@Misc{www-sqlitedownload,
+  comment =      {Added key and 'www' to label},
   title =        {SQlite Download Page},
-  howPublished = {Web Page},
+  howPublished = {Web page},
+  key          = {Sqlite},
   url =          {https://www.sqlite.org/download.html},
 }
 
 @Misc{www-tyrant-fal-labs-specs,
   status =       {incomplete},
-  Title =        {Tyrant FALLabs},
-  HowPublished = {Web Page},
-  Key =          {Tyrant},
-  Owner =        {S17-IO-3000},
-  Url =          {http://fallabs.com/tokyotyrant/spex.html}
+  title =        {Tyrant FALLabs},
+  howPublished = {Web page},
+  key =          {Tyrant},
+  owner =        {S17-IO-3000},
+  url =          {http://fallabs.com/tokyotyrant/spex.html},
 }
 
-@Misc{en.wikipedia.tyrant,
-  comment =      {ERROR},
+@Misc{www-en-wikipedia-tyrant,
+  comment =      {Added author and 'www'},
+  author  =      {{Wikipedia}}, 
   title =        {Tokyo Cabinet and Kyoto Cabinet},
-  howpublished = {Web Page},
+  howpublished = {Web page},
+  key          = {Tyrant},
   url =
                   {https://en.wikipedia.org/wiki/Tokyo_Cabinet_and_Kyoto_Cabinet},
 }
@@ -41,21 +47,24 @@
                   and Bryan Berry and Nathen Harvey},
   title =        {Roles, Environments, Attributes, and Data Bags -
                   Part 2},
-  howpublished = {Web Page},
+  howpublished = {Web page},
+  key          = {Datafu},
   url =          {http://foodfightshow.org/2013/01/roles2.html},
 }
 
-@Misc{datafu.apache.org,
-  comment =      {ERROR},
+@Misc{www-datafu-apache-org,
+  comment =      {Added 'www'and key},
   title =        {Apache DataFu},
-  howpublished = {Web Page},
+  howpublished = {Web page},
+  key          = {Datafu},
   url =          {https://datafu.apache.org/},
 }
 
 @Misc{cloudmesh.github,
   author =       {Gregor von Laszewski},
   title =        {Cloudmesh Overview},
-  howpublished = {Web Page},
+  howpublished = {Web page},
+  key          = {Cloudmesh}
   year =         2015,
   url =
                   {http://cloudmesh.github.io/introduction_to_cloud_computing/cloudmesh/overview.html},

--- a/chapters/tech/datafu.md
+++ b/chapters/tech/datafu.md
@@ -38,7 +38,7 @@ several years, the application has continued to received numerous
 contributions.  The Hourglass library concept was presented at a IEEE
 Big Data conference in 2013, and hence began receiving contributions
 and is in widespread usage at large organizations such as LinkedIN
-[@datafu.apache.org].
+[@www-datafu-apache-org].
 
 DataFu's Pig application contains a wide array of libraries that
 assist users in working with very large datasets.  Pig includes a
@@ -64,7 +64,7 @@ time frame.
 
 > "Hourglass works with input data that is partitioned by day, as this
   is a common scheme for partitioning temporal data"
-  [@datafu.apache.org].
+  [@www-datafu-apache-org].
 
 Hourglass was designed with the following two computational models in mind; fixed length vs fixed-start:
 
@@ -74,5 +74,5 @@ Hourglass was designed with the following two computational models in mind; fixe
   visitors to a site from the past 30 days.  Fixed-start: the beginning
   of the window stays constant, but the end slides forward as new input
   data becomes available. Example: a daily report summarizing all
-  visitors to a site since the site launched" [@datafu.apache.org].
+  visitors to a site since the site launched" [@www-datafu-apache-org].
 

--- a/chapters/tech/sqlite.md
+++ b/chapters/tech/sqlite.md
@@ -45,7 +45,7 @@ component, and works very well as an embedded component within
 particular applications such as web browsers, operating systems and
 mobile phones.  Google Chrome, Safari, and Android browser are just a
 few examples of web browsers that leverage SQLite as an embedded
-database platform with the application [@en.wikipedia.sqlite].SQLite
+database platform with the application [@www-en-wikipedia-sqlite].SQLite
 uses the standard SQL syntax within a standalone command prompt
 shell. Users have the ability to create, update, and delete tables as
 well as insert new records within tables. Users can also design and
@@ -59,7 +59,7 @@ with very detailed documentation.
  
 > "SQLite database files are recommended by the US Library of Congress
    as the storage format for long-term preservation of digital content"
-   [@sqliteappformat].
+   [@www-sqliteappformat].
 
 SQlite can be downloaded directly from the SQLite.org website. The
 website contains precompiled binary install files for a variety of
@@ -69,11 +69,11 @@ the download, installation and setup of the tool.
 
 > "The SQLite source code is maintained in three
   geographically-dispersed self-synchronized Fossil repositories that
-  are available for anonymous read only access" [@sqlitedownload].
+  are available for anonymous read only access" [@www-sqlitedownload].
 
 SQLite also provides bindings for several programming languages
 related to data science such as Python, R, and MATLAB
-[@en.wikipedia.sqlite].
+[@www-en-wikipedia-sqlite].
 
 
 

--- a/chapters/tech/tyrant.md
+++ b/chapters/tech/tyrant.md
@@ -9,6 +9,7 @@
 | keywords | NoSQL      |
 
 
+## old text
 
 Tyrant provides network interfaces to the database management system
 called Tokyo Cabinet. Tyrant is also called as Tokyo Tyrant. Tyrant is
@@ -22,7 +23,7 @@ Labs [@www-tyrant-fal-labs].  However, according to FAL Labs,
 their latest product Kyoto Tycoon is more powerful and convenient
 server than Tokyo Tyrant [@www-kyoto-tycoon].
 
-Technology Summary - Jay Stockwell - fa18-523-61
+## New text
 
 Tokyo Tyrant is comprised of several packages of network interfaces that link to a complex database management system entitled Tokyo Cabinet [@www-tyrant-fal-labs]. The  Tokyo Cabinet is a set of routines used for the management of key-value databases, and was initially sponsored by the Japanese social media site Mixi [@www-en-wikipedia-tyrant]. Tokyo Tyrant provides a variety of methods to connect to the Tokyo cabinet database manager. The application includes a process whereby allowing for effective database management as well as its access library for client base applications [@www-tyrant-fal-labs].
 

--- a/chapters/tech/tyrant.md
+++ b/chapters/tech/tyrant.md
@@ -24,7 +24,7 @@ server than Tokyo Tyrant [@www-kyoto-tycoon].
 
 Technology Summary - Jay Stockwell - fa18-523-61
 
-Tokyo Tyrant is comprised of several packages of network interfaces that link to a complex database management system entitled Tokyo Cabinet [@www-tyrant-fal-labs]. The  Tokyo Cabinet is a set of routines used for the management of key-value databases, and was initially sponsored by the Japanese social media site Mixi [@en.wikipedia.tyrant]. Tokyo Tyrant provides a variety of methods to connect to the Tokyo cabinet database manager. The application includes a process whereby allowing for effective database management as well as its access library for client base applications [@www-tyrant-fal-labs].
+Tokyo Tyrant is comprised of several packages of network interfaces that link to a complex database management system entitled Tokyo Cabinet [@www-tyrant-fal-labs]. The  Tokyo Cabinet is a set of routines used for the management of key-value databases, and was initially sponsored by the Japanese social media site Mixi [@www-en-wikipedia-tyrant]. Tokyo Tyrant provides a variety of methods to connect to the Tokyo cabinet database manager. The application includes a process whereby allowing for effective database management as well as its access library for client base applications [@www-tyrant-fal-labs].
 
 Below is some additional technical information from the fallabs website:
 


### PR DESCRIPTION
Updated fa18-523-61 to include 'www', author, and key changes. Updated sqlite, datafu, and tyrant summaries to use new references. 