### PR TITLE
Update techn summaries and fa18-523-61 reference file

### DIFF
--- a/bib/references-fa18-523-61.bib
+++ b/bib/references-fa18-523-61.bib
@@ -1,4 +1,4 @@
-@Misc{en-wikipedia-sqlite,
+@Misc{www-en-wikipedia-sqlite,
   author  =      {{Wikipedia}},
   title =        {SQlite},
   howpublished = {Web page},
@@ -29,7 +29,7 @@
   url =          {http://fallabs.com/tokyotyrant/spex.html},
 }
 
-@Misc{en-wikipedia-tyrant,
+@Misc{www-en-wikipedia-tyrant,
   author  =      {{Wikipedia}}, 
   title =        {Tokyo Cabinet and Kyoto Cabinet},
   howpublished = {Web page},
@@ -61,4 +61,22 @@
   key          = {Cloudmesh},
   year =         2015,
   url =         {http://cloudmesh.github.io/introduction_to_cloud_computing/cloudmesh/overview.html},
+}
+
+@Misc{cloudmesh.github.rain,
+  author       = {Cloudmesh.org},
+  title        = {Rain},
+  howpublished = {Web page},
+  key          = {Cloudmesh},
+  year         = {2014-2017},
+  url          = {http://cloudmesh.github.io/rain.html},
+}
+
+@Misc{cloudmesh.github.hpc,
+  author       = {Cloudmesh.org},
+  title        = {HPC},
+  howpublished = {Web page},
+  key          = {Cloudmesh
+  year         = {2014-2017},
+  url          = {http://cloudmesh.github.io/hpc.html},
 }

--- a/bib/references-fa18-523-61.bib
+++ b/bib/references-fa18-523-61.bib
@@ -76,7 +76,7 @@
   author       = {Cloudmesh.org},
   title        = {HPC},
   howpublished = {Web page},
-  key          = {Cloudmesh
+  key          = {Cloudmesh},
   year         = {2014-2017},
   url          = {http://cloudmesh.github.io/hpc.html},
 }

--- a/chapters/tech/cloudmesh.md
+++ b/chapters/tech/cloudmesh.md
@@ -20,16 +20,15 @@ of classes taught at Indiana University.
 ##New
 
 Cloudmesh encompasses a method which uses a client to manage virtual clusters pertaining to big data sets. 
-Cloudmesh combines various resources together to deliver a holistic application that allows for users to 
-experiment and leverage big data applications. FutureSystems, Amazon Web Services, Azure, and HP Cloud are 
-just a few examples of cloudmesh systems. Cloudmesh can function as an HPC (High Performance Computing) environment 
-by providing a simple hosted or standalone interface as well as Python and iPython API’s [@cloudmesh.github.hpc]. 
+Cloudmesh combines various resources together to deliver a holistic application that allows for users to
+experiment and leverage big data applications. FutureSystems, Amazon Web Services, Azure, and HP Cloud are
+just a few examples of cloudmesh systems. Cloudmesh can function as an HPC (High Performance Computing) environment
+by providing a simple hosted or standalone interface as well as Python and iPython APIs [@cloudmesh.github.hpc].
 The goal here is to effectively work with batch queues.  The Cloudmesh interface includes a new concept called Rain. 
 This new concept is fully integrated within Cloudmesh and provides a mechanism by which specific users can access 
 projects depending on their roles [@cloudmesh.github.rain]. This is a pertinent feature that allow for users to restrict 
-access to specific projects.  Rain includes the ability to complete any provisioning directly on the server, 
+access to specific projects.  Rain includes the ability to complete any provisioning directly on the server,
 including any type of OS provisioning. The concept is entitled bare metal provisioning [@cloudmesh.github.rain].
-
 
 There are three layers that comprise the cloudmesh architecture are described below:
 
@@ -38,20 +37,21 @@ There are three layers that comprise the cloudmesh architecture are described be
 > of services needed by an experiment, provisioning and execution environments to   be deployed on 
 > resources to (or interfaced with) enable experiment management, and resources" [@cloudmesh.github].
 
-Depending on your application needs, Cloudmesh can be set up to run either as a single host on one machine, 
-or as a multi-tenancy solution.  There are three primary services that start up allowing for the application to run effectively; Cloudmesh Database, Cloudmesh Web Service, and Cloudmesh Task Service. 
+Depending on your application needs, Cloudmesh can be set up to run either as a single host on one machine,
+or as a multi-tenancy solution.  There are three primary services that start up allowing for the application to run 
+effectively; Cloudmesh Database, Cloudmesh Web Service, and Cloudmesh Task Service.
 
 > "Cloudmesh Database: A NOSQL database in which we record which virtual machines run on which IaaS. 
-> This allows us to have a federated   view of the heterogeneous clouds. Cloudmesh Web Service: 
+> This allows us to have a federated   view of the heterogeneous clouds. Cloudmesh Web Service:
 > Provides a Graphical user interface to manage virtual machines and HPC tasks
 >  Cloudmesh Task Service: As cloudmesh is a multi user systems many tasks need to be handles in parallel. 
 > To achieve this we are using an AMPQ queue and coordinate the execution of managing multiple virtual 
 > machines for multiple users" [@cloudmesh.github].
 
-Cloudmesh has proven to work very effectively in academic settings by allowing instructors and student 
-to collaborate together on assignments and projects. Cloudmesh allows users to leverage all of their 
+Cloudmesh has proven to work very effectively in academic settings by allowing instructors and student
+to collaborate together on assignments and projects. Cloudmesh allows users to leverage all of their
 cloud based computing accounts in one location. The FutureSystems application, leveraged by students 
 from Indiana University, is an example of a Big Data cloudmesh environment that allows students to post 
-projects, share project ideas, and interact with other students and instructors.  It has proven to be 
-and effective educational tool in regards to STEM classes as it allows for immediate feature and 
-transparency of everyone’s work and code in order to provide a true learning environment. 
+projects, share project ideas, and interact with other students and instructors.  It has proven to be
+and effective educational tool in regards to STEM classes as it allows for immediate feature and
+transparency of everyones work and code in order to provide a true learning environment.

--- a/chapters/tech/cloudmesh.md
+++ b/chapters/tech/cloudmesh.md
@@ -9,6 +9,7 @@
 | keywords | Interoperability |
 
 
+##Old
 
 Cloudmesh client allows to easily manage virtual machines, containers,
 HPC tasks, through a convenient client and API. Hence cloudmesh is not
@@ -16,14 +17,20 @@ only a multi-cloud, but a multi-hpc environment that allows also to
 use container technologies. Cloudmesh is currently develloped as part
 of classes taught at Indiana University.
 
-:o: correction suggested
-
-Summary added fa-523-61
+##New
 
 Cloudmesh encompasses a method which uses a client to manage virtual clusters pertaining to big data sets. 
 Cloudmesh combines various resources together to deliver a holistic application that allows for users to 
 experiment and leverage big data applications. FutureSystems, Amazon Web Services, Azure, and HP Cloud are 
-just a few examples of cloudmesh systems. 
+just a few examples of cloudmesh systems. Cloudmesh can function as an HPC (High Performance Computing) environment 
+by providing a simple hosted or standalone interface as well as Python and iPython API’s [@cloudmesh.github.hpc]. 
+The goal here is to effectively work with batch queues.  The Cloudmesh interface includes a new concept called Rain. 
+This new concept is fully integrated within Cloudmesh and provides a mechanism by which specific users can access 
+projects depending on their roles [@cloudmesh.github.rain]. This is a pertinent feature that allow for users to restrict 
+access to specific projects.  Rain includes the ability to complete any provisioning directly on the server, 
+including any type of OS provisioning. The concept is entitled bare metal provisioning [@cloudmesh.github.rain].
+
+
 There are three layers that comprise the cloudmesh architecture are described below:
 
 > "The three layers of the Cloudmesh architecture include a Cloudmesh Management Framework for 
@@ -45,4 +52,6 @@ Cloudmesh has proven to work very effectively in academic settings by allowing i
 to collaborate together on assignments and projects. Cloudmesh allows users to leverage all of their 
 cloud based computing accounts in one location. The FutureSystems application, leveraged by students 
 from Indiana University, is an example of a Big Data cloudmesh environment that allows students to post 
-projects, share project ideas, and interact with other students and instructors.  
+projects, share project ideas, and interact with other students and instructors.  It has proven to be 
+and effective educational tool in regards to STEM classes as it allows for immediate feature and 
+transparency of everyone’s work and code in order to provide a true learning environment. 

--- a/chapters/tech/sqlite.md
+++ b/chapters/tech/sqlite.md
@@ -46,7 +46,7 @@ component, and works very well as an embedded component within
 particular applications such as web browsers, operating systems and
 mobile phones.  Google Chrome, Safari, and Android browser are just a
 few examples of web browsers that leverage SQLite as an embedded
-database platform with the application [@en-wikipedia-sqlite]. 
+database platform with the application [@www-en-wikipedia-sqlite]. 
 
 SQLite uses the standard SQL syntax within a standalone command prompt
 shell. Users have the ability to create, update, and delete tables as
@@ -79,4 +79,4 @@ the download, installation and setup of the tool.
 
 SQLite also provides bindings for several programming languages
 related to data science such as Python, R, and MATLAB
-[@en-wikipedia-sqlite].
+[@www-en-wikipedia-sqlite].

--- a/chapters/tech/tyrant.md
+++ b/chapters/tech/tyrant.md
@@ -25,14 +25,12 @@ more powerful and convenient server than Tokyo Tyrant
 
 ## New text
 
-:o: text too short
-
 Tokyo Tyrant is comprised of several packages of network interfaces
 that link to a complex database management system entitled Tokyo
 Cabinet [@www-tyrant-fal-labs]. The Tokyo Cabinet is a set of routines
 used for the management of key-value databases, and was initially
 sponsored by the Japanese social media site Mixi
-[@en.wikipedia.tyrant]. Tokyo Tyrant provides a variety of methods to
+[@www-en.wikipedia.tyrant]. Tokyo Tyrant provides a variety of methods to
 connect to the Tokyo cabinet database manager. The application
 includes a process whereby allowing for effective database management
 as well as its access library for client base applications
@@ -72,6 +70,19 @@ application.
 
 A new, more robust version of Tokyo Cabinet entitled Kyoto Cabinet has
 been released and has taken the place of the original Tokyo Cabinet
-platform.
+platform. The Kyoto Cabinet exhibits extraordinarily fast performance 
+using a smaller footprint, and is very scaleable. Kyoto Cabinet was 
+developed using the C++ language and can be leveraged as an API within 
+the Java, Python, Ruby, Perl, and Lua. [@www-kyotocabinet]. A newly 
+released database server, Kyoto Tycoon, works in tandem with Kyoto Cabinet 
+to manage the intricate web of network connections and server processes 
+for the applications for which it supports. Kyoto Tycoon is capable of 
+managing concurrent network connections to Kyoto Cabinet and functions 
+primarily as a remote network interface.  Kyoto Cabinet, used in conjunction 
+with Kyoto Tycoon, is the next step up for the Tokyo Tyrant platform and is 
+touted as being far superior and highly recommended as a necessary replacement. 
+Fal Labs, the architects of Tokyo Tyrant strongly recommend upgrading in order 
+to take advantage of the new features of Kyoto Cabinet and Kyoto Tycoon 
+[@www-tyrant-fal-labs].
 
 


### PR DESCRIPTION
Updated tech summaries as instructed by TA's. Updated fa18-523-reference file to include new Cloudmesh entries and 'www' within wikipedia labels. 