### PR TITLE
Update tyrant.md

### DIFF
--- a/chapters/tech/tyrant.md
+++ b/chapters/tech/tyrant.md
@@ -30,7 +30,7 @@ that link to a complex database management system entitled Tokyo
 Cabinet [@www-tyrant-fal-labs]. The Tokyo Cabinet is a set of routines
 used for the management of key-value databases, and was initially
 sponsored by the Japanese social media site Mixi
-[@www-en.wikipedia.tyrant]. Tokyo Tyrant provides a variety of methods to
+[@www-en-wikipedia-tyrant]. Tokyo Tyrant provides a variety of methods to
 connect to the Tokyo cabinet database manager. The application
 includes a process whereby allowing for effective database management
 as well as its access library for client base applications


### PR DESCRIPTION
Corrected minor issue with wikipedia reference in tyrant summary. Changed 'www.en.wikipedia.tyrant' to 'www-en-wikipedia-tyrant'